### PR TITLE
refactor(observability) Improve performance of Pinecone fetching

### DIFF
--- a/lib/s3_mongodb_cdk_stack.ts
+++ b/lib/s3_mongodb_cdk_stack.ts
@@ -161,8 +161,8 @@ export class S3_MongoDB_CDK_Stack extends Stack {
         EMBEDDING_MODEL_NAME: process.env.EMBEDDING_MODEL_NAME!,
         EMBEDDING_PROVIDER_API_KEY:
           process.env.EMBEDDING_PROVIDER_API_KEY || "",
-        CHUNKING_STRATEGY: process.env.CHUNKING_STRATEGY!,
-        CHUNKING_MAX_CHARACTERS: process.env.CHUNKING_MAX_CHARACTERS!,
+        CHUNKING_STRATEGY: process.env.CHUNKING_STRATEGY || "",
+        CHUNKING_MAX_CHARACTERS: process.env.CHUNKING_MAX_CHARACTERS || "",
         MONGODB_URI: process.env.MONGODB_URI!,
         MONGODB_DATABASE: process.env.MONGODB_DATABASE!,
         MONGODB_COLLECTION: process.env.MONGODB_COLLECTION!,

--- a/lib/s3_postgres_cdk_stack.ts
+++ b/lib/s3_postgres_cdk_stack.ts
@@ -161,8 +161,8 @@ export class S3_Postgres_CDK_Stack extends Stack {
         EMBEDDING_MODEL_NAME: process.env.EMBEDDING_MODEL_NAME!,
         EMBEDDING_PROVIDER_API_KEY:
           process.env.EMBEDDING_PROVIDER_API_KEY || "",
-        CHUNKING_STRATEGY: process.env.CHUNKING_STRATEGY!,
-        CHUNKING_MAX_CHARACTERS: process.env.CHUNKING_MAX_CHARACTERS!,
+        CHUNKING_STRATEGY: process.env.CHUNKING_STRATEGY || "",
+        CHUNKING_MAX_CHARACTERS: process.env.CHUNKING_MAX_CHARACTERS || "",
         POSTGRES_DB_NAME: process.env.POSTGRES_DB_NAME!,
         POSTGRES_USER: process.env.POSTGRES_USER!,
         POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD!,


### PR DESCRIPTION
In the previous version of the Lambda, there was a possibility that the incorrect Websocket connection ID was used to send the Websocket message because the connection_id is retrieved from DynamoDB prior to running the process_new_logs function which can take some time to run.

If the user refreshed or switched tabs, a new Websocket connection would be created with a new connection ID so the old one would be invalid by the time the Lambda is ready to send the Websocket message. The logs are still saved in the DynamoDB table so the logs are never lost but this is just an improvement for user friendliness.

This refactor retrieves the connection_id after the process_new_logs function has completed and immediately before the information is passed to the Websocket client, thereby greatly minimizing the chance of sending to a stale connection.

I also refactored the fetching of total vectors and total documents in the Pinecone database. When we check for these values, if Pinecone updated quickly, we would receive the correct counts but if Pinecone is slow to update on their end, we would receive the old counts and would need to re-fetch the data at a later time to get the "true" count. Unfortunately, we have no way of knowing if the original count we fetched is the true count or if the true count has not updated yet.

Previously, the function would wait 10 seconds which was sufficient time to allow Pinecone to update on their end. This new refactor will check Pinecone every 3 seconds for 3 iterations. If the count that we receive from Pinecone changes, we know that this new count is the true count and we can exit early. If the count does not change after 3 iterations, then the original count that we fetched actually was the true count and we can return this value. Overall this refactor should improve the performance over an arbitrary delay time.